### PR TITLE
add USF away to name-image map

### DIFF
--- a/stat_explorer/src/constants/games.js
+++ b/stat_explorer/src/constants/games.js
@@ -148,6 +148,7 @@ export const gameNameToUrl = {
     "Gonzaga": "https://byucougars.com/sites/default/files/styles/thumbnail/public/Athletic_Logo/Gonzaga_Primary.png?itok=LcpDQizp",
     "Pepperdine": "https://byucougars.com/sites/default/files/styles/thumbnail/public/files/university_logos/pepp_0.png?itok=lc3Z2_eL",
     "Santa Clara (A)": "https://byucougars.com/sites/default/files/styles/thumbnail/public/Athletic_Logo/school_logo_detail_page_0.png?itok=rmpq8YAE", 
+    "San Francisco (A)": "https://byucougars.com/sites/default/files/styles/thumbnail/public/files/university_logos/usf_0.png?itok=eH1z_OPe",
 };
 
 export function gameFromId (gameId) {


### PR DESCRIPTION
left out the image in the name-image map, currently broken in games breakdown in season without this update