### PR TITLE
add sorting for game and season lineup tables

### DIFF
--- a/stat_explorer/src/components/SortableHeader/SortableHeader.css
+++ b/stat_explorer/src/components/SortableHeader/SortableHeader.css
@@ -1,0 +1,19 @@
+.sort-header {
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    cursor: pointer;
+}
+
+.sort-header:hover {
+    background-color: #004ead;
+}
+
+.sort-header.sort--asc {
+    border-bottom-color: white;
+    background-color: #004ead;
+}
+
+.sort-header.sort--desc {
+    border-top-color: white;
+    background-color: #004ead;
+}

--- a/stat_explorer/src/components/SortableHeader/SortableHeader.js
+++ b/stat_explorer/src/components/SortableHeader/SortableHeader.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import "./SortableHeader.css";
+import { SORT_KEYS } from '../../constants/sorting';
+
+export default function SortableHeader ({classes, sortDirection, sortKey, onHeaderClick, children}) {
+    function handleClick () {
+        if (onHeaderClick) {
+            let newDirection = '';
+            if (!sortDirection) {
+                newDirection = SORT_KEYS.DESC;
+            } else if (sortDirection === SORT_KEYS.DESC) {
+                newDirection = SORT_KEYS.ASC;
+            }        
+            onHeaderClick(sortKey, newDirection);
+        }
+    }
+
+    const additionalClasses = classes.split(' ');
+    const headerClass = [...additionalClasses, 'sort-header'];
+    if (sortDirection === SORT_KEYS.ASC) {
+        headerClass.push('sort--asc');
+    } else if (sortDirection === SORT_KEYS.DESC) {
+        headerClass.push('sort--desc');
+    }
+
+    return (
+        <div className={headerClass.join(' ')} role="button" onClick={handleClick}>
+            { children }
+        </div>
+    );
+}

--- a/stat_explorer/src/constants/sorting.js
+++ b/stat_explorer/src/constants/sorting.js
@@ -1,0 +1,4 @@
+export const SORT_KEYS = {
+    ASC: 'ASC',
+    DESC: 'DESC',
+};

--- a/stat_explorer/src/styles/mobile.css
+++ b/stat_explorer/src/styles/mobile.css
@@ -89,4 +89,11 @@
   div.lineup-summary {
     margin-bottom: var(--m);
   }
+
+  div.sort-header {
+    height: calc(100% - var(--m) - var(--m) - 4px - 4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }

--- a/stat_explorer/src/styles/variables.css
+++ b/stat_explorer/src/styles/variables.css
@@ -25,4 +25,5 @@
   --m: 1rem;
   --l: 1.5rem;
   --xl: 2rem;
+  --border-indicator-width: 4px;
 }

--- a/stat_explorer/src/utils/gameLineupSorters.js
+++ b/stat_explorer/src/utils/gameLineupSorters.js
@@ -1,0 +1,21 @@
+import { getLineupHash } from "./lineupUtils";
+
+export const GAME_SORT_KEYS ={
+    NAME: 'name',
+    MINS: 'totalTime',
+    NET: 'totalNet',
+    SEEN: 'timesSeen'
+};
+
+export const GAME_CUSTOM_SORTERS = {
+    [GAME_SORT_KEYS.NAME]: {
+        dataMapper: (lineup) => {
+            return { ...lineup, [GAME_SORT_KEYS.NAME]: getLineupHash(lineup.names)};
+        }
+    },
+    [GAME_SORT_KEYS.SEEN]: {
+        dataMapper: (lineup) => {
+            return { ...lineup, [GAME_SORT_KEYS.SEEN]: lineup.stints.length };
+        }
+    }
+};

--- a/stat_explorer/src/utils/lineupSorters.js
+++ b/stat_explorer/src/utils/lineupSorters.js
@@ -21,3 +21,31 @@ export function makeSortDescByKey (key) {
         return 0;
     };
 }
+
+export function makeAvgAscSort(key, total) {
+    return (objA, objB) => {
+        const avgA = objA[key] / total;
+        const avgB = objB[key] / total;
+        if (avgA > avgB) {
+            return 1;
+        }
+        if (avgA < avgB) {
+            return -1;
+        }
+        return 0;
+    }
+}
+
+export function makeAvgDescSort(key, total) {
+    return (objA, objB) => {
+        const avgA = objA[key] / total;
+        const avgB = objB[key] / total;
+        if (avgA < avgB) {
+            return 1;
+        }
+        if (avgA > avgB) {
+            return -1;
+        }
+        return 0;
+    }
+}

--- a/stat_explorer/src/utils/seasonLineupSorters.js
+++ b/stat_explorer/src/utils/seasonLineupSorters.js
@@ -1,0 +1,21 @@
+import { getLineupHash } from "./lineupUtils";
+
+export const SEASON_SORT_KEYS ={
+    NAME: 'name',
+    MINS: 'totalMinutes',
+    NET: 'totalNet',
+    AVG: 'avg'
+};
+
+export const SEASON_CUSTOM_SORTERS = {
+    [SEASON_SORT_KEYS.NAME]: {
+        dataMapper: (lineup) => {
+            return { ...lineup, [SEASON_SORT_KEYS.NAME]: getLineupHash(lineup.names)};
+        }
+    },
+    [SEASON_SORT_KEYS.AVG]: {
+        dataMapper: (lineup) => {
+            return { ...lineup, [SEASON_SORT_KEYS.AVG]: lineup.totalMinutes / lineup.games.length };
+        }
+    }
+};

--- a/stat_explorer/src/views/Lineups/components/LineupTable.js
+++ b/stat_explorer/src/views/Lineups/components/LineupTable.js
@@ -4,8 +4,10 @@ import { getLineupHash } from '../../../utils/lineupUtils';
 import { condenseStints, namesToReadable, getStintsLabel } from '../../../utils/playerLineupUtils';
 import LineupStints from './LineupStints';
 import Net from '../../../components/Net/Net';
+import SortableHeader from '../../../components/SortableHeader/SortableHeader';
+import { GAME_SORT_KEYS } from '../../../utils/gameLineupSorters';
 
-export default function LineupTable ({lineups, filterPlayers, summary}) {
+export default function LineupTable ({lineups, filterPlayers, summary, onSortClick, currSortKey, currSortDir}) {
   const [showSummary, setShowSummary] = useState(false);
   function handleToggleShow () {
     setShowSummary(!showSummary);
@@ -71,11 +73,39 @@ export default function LineupTable ({lineups, filterPlayers, summary}) {
           <div className='circle-badge ender-badge mr-xs'>E</div>
           <span className="lineup-table__legend__text">- End of game lineup</span>
         </div>
-        <div className='lineup-table__headers py-m flex-aic'>
-          <div className='lr--lineup lineup-header'>Lineup</div>
-          <div className='lr--time lineup-header f1'>Total Time</div>
-          <div className='lr--stint-count lineup-header f1'>Times Seen</div>
-          <div className='lr--net lineup-header f1'>+ / -</div>
+        <div className='lineup-table__headers flex-aic'>
+          <SortableHeader 
+            classes='lr--lineup lineup-header'
+            sortDirection={currSortKey === GAME_SORT_KEYS.NAME ? currSortDir : ''}
+            sortKey={GAME_SORT_KEYS.NAME}
+            onHeaderClick={onSortClick}
+          >
+              Lineup
+          </SortableHeader>
+          <SortableHeader 
+            classes='lr--time lineup-header f1'
+            sortDirection={currSortKey === GAME_SORT_KEYS.MINS ? currSortDir : ''}
+            sortKey={GAME_SORT_KEYS.MINS}
+            onHeaderClick={onSortClick}
+          >
+              Total Time
+          </SortableHeader>
+          <SortableHeader 
+            classes='lr--stint-count lineup-header f1'
+            sortDirection={currSortKey === GAME_SORT_KEYS.SEEN ? currSortDir : ''}
+            sortKey={GAME_SORT_KEYS.SEEN}
+            onHeaderClick={onSortClick}
+          >
+              Times Seen
+          </SortableHeader>
+          <SortableHeader 
+            classes='lr--net lineup-header f1'
+            sortDirection={currSortKey === GAME_SORT_KEYS.NET ? currSortDir : ''}
+            sortKey={GAME_SORT_KEYS.NET}
+            onHeaderClick={onSortClick}
+          >
+              + / -
+          </SortableHeader>
         </div>
         <div className='lineup-table__body f1-scroll'>
           {

--- a/stat_explorer/src/views/Lineups/components/SeasonLineupTable.js
+++ b/stat_explorer/src/views/Lineups/components/SeasonLineupTable.js
@@ -6,8 +6,10 @@ import { aggregateGamesForLineups } from '../../../utils/seasonLineups';
 import { gameNameToUrl } from '../../../constants/games';
 import LineupSummary from './LineupSummary';
 import Net from '../../../components/Net/Net';
+import SortableHeader from '../../../components/SortableHeader/SortableHeader';
+import { SEASON_SORT_KEYS } from '../../../utils/seasonLineupSorters';
 
-export default function LineupTable ({lineups, filterPlayers,summary}) {
+export default function LineupTable ({lineups, filterPlayers,summary, onSortClick, currSortKey, currSortDir}) {
   const [showSummary, setShowSummary] = useState(false);
 
   function handleToggleShow () {
@@ -78,16 +80,44 @@ export default function LineupTable ({lineups, filterPlayers,summary}) {
       </div>
     );
   }
-
+  
   return (
     <div className='lineup-table f1-hide flex-c'>
         {!!filterPlayers?.length && renderFilterCount()}
         {!!filterPlayers?.length && renderFilteredSummary()}
-        <div className='lineup-table__headers py-m flex-aic'>
-          <div className='lr--lineup lineup-header'>Lineup</div>
-          <div className='lr--time lineup-header f1'>Total Time</div>
-          <div className='lr--stint-count lineup-header f1'>Min / g</div>
-          <div className='lr--net lineup-header f1'>+ / -</div>
+        <div className='lineup-table__headers flex-aic'>
+          <SortableHeader 
+            classes='lr--lineup lineup-header'
+            sortDirection={currSortKey === SEASON_SORT_KEYS.NAME ? currSortDir : ''}
+            sortKey={SEASON_SORT_KEYS.NAME}
+            onHeaderClick={onSortClick}
+          >
+              Lineup
+          </SortableHeader>
+          <SortableHeader 
+            classes='lr--time lineup-header f1'
+            sortDirection={currSortKey === SEASON_SORT_KEYS.MINS ? currSortDir : ''}
+            sortKey={SEASON_SORT_KEYS.MINS}
+            onHeaderClick={onSortClick}
+          >
+              Total Time
+          </SortableHeader>
+          <SortableHeader 
+            classes='lr--stint-count lineup-header f1'
+            sortDirection={currSortKey === SEASON_SORT_KEYS.AVG ? currSortDir : ''}
+            sortKey={SEASON_SORT_KEYS.AVG}
+            onHeaderClick={onSortClick}
+          >
+              Min / g
+          </SortableHeader>
+          <SortableHeader 
+            classes='lr--net lineup-header f1'
+            sortDirection={currSortKey === SEASON_SORT_KEYS.NET ? currSortDir : ''}
+            sortKey={SEASON_SORT_KEYS.NET}
+            onHeaderClick={onSortClick}
+          >
+              + / -
+          </SortableHeader>
         </div>
         <div className='lineup-table__body f1-scroll'>
           {

--- a/stat_explorer/src/views/Lineups/components/SeasonLineups.js
+++ b/stat_explorer/src/views/Lineups/components/SeasonLineups.js
@@ -1,16 +1,20 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import PlayerFilters from "../../../components/PlayerFilters/PlayerFilters";
 import "../Lineups.css";
 import SeasonLineupTable from "./SeasonLineupTable";
 import BlockFaceLoader from '../../../components/Loaders/BlockFaceLoader';
 import urls from '../../../constants/assetUrls';
 import {checknames} from '../../../constants/playerInfo';
+import { SEASON_CUSTOM_SORTERS, SEASON_SORT_KEYS } from "../../../utils/seasonLineupSorters";
+import { SORT_KEYS } from "../../../constants/sorting";
+import { makeSortAscByKey, makeSortDescByKey } from "../../../utils/lineupSorters";
 
 export default function SeasonLineups() {
   const [loading, setLoading] = useState(true);
   const players = checknames;
   // console.log('players', players);
   const [filterPlayers, setFilterPlayers] = useState([]);
+  const [currSort, setCurrSort] = useState({key: SEASON_SORT_KEYS.NET, direction: SORT_KEYS.DESC});
   const [lineupData, setLineupData] = useState({});
   function onPlayerChange(player) {
     const newFilters = [...filterPlayers];
@@ -22,6 +26,13 @@ export default function SeasonLineups() {
     }
     setFilterPlayers(newFilters);
   }
+
+  function handleSortClick(newKey, newDir) {
+    setCurrSort({
+      key: newDir.length ? newKey : '',
+      direction: newDir
+    })
+  };
 
   useEffect(() => {
     fetch(urls.seasonLineups)
@@ -38,31 +49,45 @@ export default function SeasonLineups() {
         console.error(callErr);
       });
   }, []);
-  const currentLineupKeys = Object.keys(lineupData).sort();
-  // console.log('currentLineupKey', currentLineupKeys);
-  const filteredLineups = currentLineupKeys.reduce((agg, key) => {
-    const lineup = lineupData[key];
-    let include = true;
-    if (filterPlayers.length) {
-      include = filterPlayers.every((p) => lineup.names.includes(p));
-    }
-    if (include) {
-      agg.lineups.push(lineup);
+
+  const lineupCount = Object.keys(lineupData).length;
+  const currentLineupData = useMemo(() => {
+    const currentLineupKeys = Object.keys(lineupData).sort();
+    const filteredLineupData = currentLineupKeys.reduce((agg, key) => {
+      const lineup = lineupData[key];
+      let include = true;
       if (filterPlayers.length) {
-        agg.summary.net = agg.summary.net + lineup.totalNet;
-        agg.summary.mins = agg.summary.mins + lineup.totalMinutes;
-        if (lineup.totalNet > agg.summary.maxNet) {
-            agg.summary.maxNet = lineup.totalNet;
-        } else if (lineup.totalNet < agg.summary.minNet) {
-            agg.summary.minNet = lineup.totalNet;
+        include = filterPlayers.every((p) => lineup.names.includes(p));
+      }
+      if (include) {
+        agg.lineups.push(lineup);
+        if (filterPlayers.length) {
+          agg.summary.net = agg.summary.net + lineup.totalNet;
+          agg.summary.mins = agg.summary.mins + lineup.totalMinutes;
+          if (lineup.totalNet > agg.summary.maxNet) {
+              agg.summary.maxNet = lineup.totalNet;
+          } else if (lineup.totalNet < agg.summary.minNet) {
+              agg.summary.minNet = lineup.totalNet;
+          }
         }
       }
+      return agg;
+    }, { lineups: [], summary: { net: 0, mins: 0, maxNet: 0, minNet: 300}});
+    let sortedLineups = filteredLineupData.lineups;
+    if (currSort.key) {
+      const sortConfig = SEASON_CUSTOM_SORTERS[currSort.key];
+      let sortLineups = [...sortedLineups];
+      if (sortConfig?.dataMapper) {
+        sortLineups = sortLineups.map(sortConfig.dataMapper);
+      }
+      const sorter = currSort.direction === SORT_KEYS.ASC ? makeSortAscByKey(currSort.key) : makeSortDescByKey(currSort.key);
+      sortedLineups = sortLineups.sort(sorter);
     }
-    return agg;
-  }, { lineups: [], summary: { net: 0, mins: 0, maxNet: 0, minNet: 300}});
-  // console.log('filteredLineups', filteredLineups);
-  const currentLineups = filteredLineups.lineups.sort((lA, lB) => lB.totalMinutes - lA.totalMinutes);
-  // console.log('currentLineups', currentLineups);
+    return {
+      lineups: sortedLineups,
+      summary: filteredLineupData.summary,
+    };
+  }, [filterPlayers.length, lineupCount, currSort.key, currSort.direction]);
   return (
     <>
         <h1 className="lineup-game-label">Season Lineups</h1>
@@ -72,10 +97,17 @@ export default function SeasonLineups() {
           onChange={onPlayerChange}
         />
         {loading && <BlockFaceLoader />}
-        {!loading && currentLineupKeys.length && (
+        {!loading && (
           <div className="f1-hide flex-c">
-            {filterPlayers.length < 1 && <h4 className="lineups__totals">{`Total Lineups: ${currentLineupKeys.length}`}</h4>}
-            <SeasonLineupTable summary={filteredLineups.summary} lineups={currentLineups} filterPlayers={filterPlayers}/>
+            {filterPlayers.length < 1 && <h4 className="lineups__totals">{`Total Lineups: ${currentLineupData.lineups.length}`}</h4>}
+            <SeasonLineupTable
+              summary={currentLineupData.summary}
+              lineups={currentLineupData.lineups}
+              filterPlayers={filterPlayers}
+              onSortClick={handleSortClick}
+              currSortKey={currSort.key}
+              currSortDir={currSort.direction}
+            />
           </div>
         )}
     </>

--- a/stat_explorer/src/views/Lineups/styles/SeasonLineupTable.css
+++ b/stat_explorer/src/views/Lineups/styles/SeasonLineupTable.css
@@ -1,3 +1,11 @@
+.lineup-table__headers {
+    border: 1px solid var(--blue-stop-3);
+}
+
+.lineup-header {
+    padding: var(--m) 0 var(--m) 0;
+}
+
 .game {
     filter: opacity(0.85);
     padding-top: var(--s);


### PR DESCRIPTION
Adds in sortable table headers for both game and season lineup tables. Also touches up some styling to make things a little better on mobile

<img width="824" alt="Screen Shot 2023-01-26 at 4 11 13 PM" src="https://user-images.githubusercontent.com/11298654/214971345-3142f2d7-abc3-4e5f-9c62-3a857dfd4cbb.png">
